### PR TITLE
add an in-memory-cache for function-signatures

### DIFF
--- a/lib/src/domain/entities/transactions/evm_transaction.dart
+++ b/lib/src/domain/entities/transactions/evm_transaction.dart
@@ -113,6 +113,11 @@ abstract base class EVMTransaction extends GenericTransaction {
   });
 
   FunctionSignature get getFunctionSignature {
-    return FunctionSignature.fromData(input);
+    if (!_cachedFunctionSigs.containsKey(hash)) {
+      _cachedFunctionSigs[hash] = FunctionSignature.fromData(input);
+    }
+    return _cachedFunctionSigs[hash]!;
   }
 }
+
+Map<String, FunctionSignature> _cachedFunctionSigs = {};


### PR DESCRIPTION
for things like derived transaction-details, the walletkit should provide in-memory-caches.
This should be very simple to implement because transactions should never change at runtime