### PR TITLE
refactor: Update ConfirmationStatus enum values to lowercase (#commit)

### DIFF
--- a/lib/src/domain/entities/transactions/generic_transaction.dart
+++ b/lib/src/domain/entities/transactions/generic_transaction.dart
@@ -101,19 +101,19 @@ base class GenericTransaction implements Comparable<GenericTransaction> {
 @HiveType(typeId: 18)
 enum ConfirmationStatus {
   @HiveField(0)
-  notSubmitted("Not Submitted"),
+  notSubmitted("not_submitted"),
 
   /// Transaction is not confirmed yet
   @HiveField(1)
-  pending("Pending"),
+  pending("pending"),
 
   /// Transaction is confirmed
   @HiveField(2)
-  confirmed("Confirmed"),
+  confirmed("confirmed"),
 
   /// Transaction is failed
   @HiveField(3)
-  failed("Failed");
+  failed("failed");
 
   /// TODO: When is a transaction failed?
   static ConfirmationStatus fromConfirmations(int? confirmations) {


### PR DESCRIPTION
The ConfirmationStatus enum values in the GenericTransaction class have been updated to use lowercase strings instead of title case. This change improves consistency and adheres to the established naming conventions in the codebase.