### PR TITLE
Refactor EvmRpcInterface

### DIFF
--- a/lib/src/crypto/evm/repositories/rpc/evm_rpc_interface.dart
+++ b/lib/src/crypto/evm/repositories/rpc/evm_rpc_interface.dart
@@ -26,6 +26,7 @@ final class EvmRpcInterface {
     bool awaitRefresh = true,
     Duration? refreshIntervall,
     bool eagerError = false,
+    RefreshType refreshType = RefreshType.onTask,
     required List<EvmRpcClient> clients,
     required this.type,
   }) : _manager = useQueuedManager
@@ -34,12 +35,14 @@ final class EvmRpcInterface {
                 clientRefreshRate: refreshIntervall,
                 allClients: clients,
                 eagerError: eagerError,
+                refreshType: refreshType,
               )
             : SimpleRpcManager(
                 awaitRefresh: awaitRefresh,
                 clientRefreshRate: refreshIntervall,
                 allClients: clients,
                 eagerError: eagerError,
+                refreshType: refreshType,
               );
 
   Future<T> performTask<T>(


### PR DESCRIPTION
- The `refreshType` parameter allows specifying when the clients should be refreshed
- If `refreshType` is set to `RefreshType.onInit`, the clients are refreshed on initialization and periodically based on `clientRefreshRate`
- If `refreshType` is set to `RefreshType.onTask`, the clients are refreshed before performing a task if the refresh is not already completed