### PR TITLE
Implement a RPC ManagerFunction: performTaskForMultipleClients

### DIFF
--- a/lib/src/crypto/evm/repositories/rpc/evm_rpc_interface.dart
+++ b/lib/src/crypto/evm/repositories/rpc/evm_rpc_interface.dart
@@ -56,6 +56,19 @@ final class EvmRpcInterface {
   }) =>
       _manager.performTask(task, timeout: timeout, maxTries: maxTries);
 
+  Future<Map<EvmRpcClient, T>> performTaskForMultipleClients<T>(
+    Future<T> Function(EvmRpcClient client) task, {
+    Duration timeout = const Duration(seconds: 30),
+    int? maxTries,
+    int? maxClients,
+  }) =>
+      _manager.performTaskForMultipleClients(
+        task,
+        timeout: timeout,
+        maxTries: maxTries,
+        maxClients: maxClients,
+      );
+
   ///
   /// eth_call
   ///


### PR DESCRIPTION
This will be used for broadcasting Transactions to prevent a faulty RPCs causing the transaction not to be shown on the blockchain