### PR TITLE
Transition Zeniqscan to BlockscoutApi

### DIFF
--- a/lib/src/crypto/evm/repositories/etherscan/etherscan_explorer.dart
+++ b/lib/src/crypto/evm/repositories/etherscan/etherscan_explorer.dart
@@ -10,10 +10,9 @@ enum Sorting { asc, desc }
 class EtherscanExplorer extends EtherscanRepository {
   final EvmCoinEntity currency;
 
-  EtherscanExplorer(super.base, super.apiKeys, this.currency);
+  EtherscanExplorer(super.baseUrl, super.apiKeys, this.currency);
 
-  @override
-  String get base => "${super.base}?chainid=${currency.chainID}";
+  String get base => "${super.baseUrl}?chainid=${currency.chainID}";
 
   String buildBalanceEndpoint(String address) =>
       "$base&module=account&action=balance&address=$address"
@@ -321,41 +320,6 @@ class ZeniqScanExplorer extends EtherscanExplorer {
   ZeniqScanExplorer(super.base, super.apiKeys, super.currency);
 
   @override
-  String buildTransactionEndpoint({
-    required String address,
-    int? startblock,
-    int? endblock,
-    int? page,
-    int? offset,
-    Sorting? sorting,
-  }) {
-    return "$base&module=account&action=txlist&address=$address"
-        .addOptionalParameter('start_block', startblock)
-        .addOptionalParameter('end_block', endblock)
-        .addOptionalParameter('page', page)
-        .addOptionalParameter('offset', offset)
-        .addOptionalParameter('sort', sorting?.name);
-  }
-
-  @override
-  String buildERC20TransactionEndpoint({
-    required String address,
-    required String contractAddress,
-    int? startblock,
-    int? endblock,
-    int? page,
-    int? offset,
-    Sorting? sorting,
-  }) {
-    return "$base&module=account&action=tokentx&address=$address&contractaddress=$contractAddress"
-        .addOptionalParameter('start_block', startblock)
-        .addOptionalParameter('end_block', endblock)
-        .addOptionalParameter('page', page)
-        .addOptionalParameter('offset', offset)
-        .addOptionalParameter('sort', sorting?.name);
-  }
-
-  @override
   String buildERC1155TransactionEndpoint({
     required String address,
     required String contractAddress,
@@ -365,11 +329,8 @@ class ZeniqScanExplorer extends EtherscanExplorer {
     int? offset,
     Sorting? sorting,
   }) {
-    return "$base&module=account&action=tokentx&address=$address&contractaddress=$contractAddress"
-        .addOptionalParameter('start_block', startblock)
-        .addOptionalParameter('end_block', endblock)
-        .addOptionalParameter('page', page)
-        .addOptionalParameter('offset', offset)
-        .addOptionalParameter('sort', sorting?.name);
+    throw UnsupportedError(
+      "Building ERC1155 Transaction Endpoint not supported",
+    );
   }
 }

--- a/lib/src/crypto/evm/repositories/etherscan/etherscan_repository.dart
+++ b/lib/src/crypto/evm/repositories/etherscan/etherscan_repository.dart
@@ -4,7 +4,7 @@ import 'package:walletkit_dart/src/common/http_client.dart';
 import 'package:walletkit_dart/src/common/logger.dart';
 
 class EtherscanRepository {
-  final String base;
+  final String baseUrl;
   final List<String> apiKeys;
   final Map<String, bool> endpointNeedsApiKey = {};
   final Map<String, DateTime> apiKeyExcludedUntil = {};
@@ -14,7 +14,7 @@ class EtherscanRepository {
   final Duration apiKeyRetryIntervall;
 
   EtherscanRepository(
-    this.base,
+    this.baseUrl,
     this.apiKeys, {
     this.noApiKeyRetryIntervall = const Duration(seconds: 5),
     this.apiKeyRetryIntervall = const Duration(seconds: 3),

--- a/test/ci/evm/evm_explorer_test.dart
+++ b/test/ci/evm/evm_explorer_test.dart
@@ -55,13 +55,13 @@ void main() {
   );
 
   test('test erc1155 fetching zsc', () async {
-    final transactions = await zeniqScan.fetchERC1155Transactions(
-      address: arbitrumTestWallet,
-      contractAddress: "0xB868a4d85c3f7207106145eB41444c5313C97D86",
+    expectLater(
+      zeniqScan.fetchERC1155Transactions(
+        address: arbitrumTestWallet,
+        contractAddress: "0xB868a4d85c3f7207106145eB41444c5313C97D86",
+      ),
+      throwsUnsupportedError,
     );
-
-    print('ERC1155 Transactions: $transactions');
-    expect(transactions, isNotEmpty);
   });
 
   test('Test Ethereum Etherscan Fetching', () async {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error handling for unsupported ERC1155 transaction queries in the ZeniqScan explorer, ensuring users receive clear feedback when attempting this operation.

- **Tests**
  - Adjusted tests to verify that unsupported ERC1155 transaction queries now correctly throw an error instead of returning data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->